### PR TITLE
Broken link fixes in website docs

### DIFF
--- a/crate/guides/about.md
+++ b/crate/guides/about.md
@@ -34,7 +34,7 @@ are worth it.
 
 Check out the [Code comparison](https://seed-rs.org/guide/code-comparison) section of this guide. Additionally,
 the [todomvc example](https://github.com/seed-rs/seed/tree/master/examples/todomvc) is an implementation of 
-the [TodoMVC project](https://todomvc.com/),
+the [TodoMVC project](http://todomvc.com/),
 which has example code in other frameworks that produce identitcal apps. Compare the example in this
 project to one on that page that uses a framework you're familiar with.
 
@@ -106,7 +106,7 @@ be a versatile, standardized toolkit.
 - Alex Chrichton, for being extraodinarily helpful in the Rust / WASM community
 - The [Elm](https://elm-lang.org/) team, for creating and standardizing the Elm architecture
 - Mozilla, for excellent DOM documentation
-- Denis Kolodin, for creating the inspirational [Yew framework](https://github.com/DenisKolodin/yew)
+- Denis Kolodin, for creating the inspirational [Yew framework](https://github.com/yewstack/yew)
 - Utkarsh Kukreti, for through his [Draco repo](https://github.com/utkarshkukreti/draco),
   helping me understand how wasm-bindgen's
   closure system can be used to update state.
@@ -114,11 +114,11 @@ be a versatile, standardized toolkit.
 
 ## Reference
 
-- [wasm-bindgen guide](https://rustwasm.github.io/wasm-bindgen/introduction.html)
+- [wasm-bindgen guide](https://rustwasm.github.io/docs/wasm-bindgen/)
 - [Mozilla MDN web docs](https://developer.mozilla.org/en-US/)
 - [web-sys api](https://rustwasm.github.io/wasm-bindgen/api/web_sys/) (A good partner for the MDN docs - most DOM items have web-sys equivalents used internally)
 - [Rust book](https://doc.rust-lang.org/book/index.html)
 - [Rust standard library api](https://doc.rust-lang.org/std/)
 - [Seed's API docs](https://docs.rs/seed)
 - [Learn Rust](https://www.rust-lang.org/learn)
-- [Testing in Headless Browsers](https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/browsers.html)
+- [Testing in Headless Browsers](https://rustwasm.github.io/docs/wasm-bindgen/wasm-bindgen-test/browsers.html)

--- a/crate/guides/events.md
+++ b/crate/guides/events.md
@@ -1,5 +1,5 @@
 # Events
-Events are created by passing [Listener](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Listener.html)s,
+Events are created by passing [Listener](https://docs.rs/seed/latest/seed/virtual_dom/event_handler_manager/listener/struct.Listener.html)s,
 or vecs of Listeners into `Node` macros. They're created using the following functions exposed in the prelude: `simple_ev`,
 `input_ev`, `keyboard_ev`, `mouse_ev`, and `raw_ev`. The first is demonstrated in the example in the quickstart section,
 and all are demonstrated in the todomvc example.

--- a/crate/guides/fetch.md
+++ b/crate/guides/fetch.md
@@ -1,8 +1,8 @@
 # HTTP Requests (fetch)
 
-We use the [seed::Request](https://docs.rs/seed/0.5.1/seed/fetch/struct.Request.html) struct
+We use the [seed::Request](https://docs.rs/seed/latest/seed/browser/service/fetch/struct.Request.html) struct
 to make HTTP requests in the browser, wrapping the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
-To use this, we need to include `futures = "^0.1.26"` in `Cargo.toml`. The [Fetch module](https://docs.rs/seed/0.5.1/seed/fetch/index.html)
+To use this, we need to include `futures = "^0.1.26"` in `Cargo.toml`. The [Fetch module](https://docs.rs/seed/latest/seed/browser/service/fetch/index.html)
 is standalone: It can be used with any wasm-bindgen program.
 
 ## Receiving data

--- a/crate/guides/js.md
+++ b/crate/guides/js.md
@@ -53,4 +53,4 @@ passes data that can be deserialized into the model.
 Note that you can also pass arguments to JS functions like this.
 
 
-For more info, reference [this wasm-bindgen example](https://rustwasm.github.io/wasm-bindgen/examples/import-js.html).
+For more info, reference [this wasm-bindgen example](https://rustwasm.github.io/docs/wasm-bindgen/examples/import-js.html).

--- a/crate/guides/misc.md
+++ b/crate/guides/misc.md
@@ -20,7 +20,7 @@ custom![ Tag::from("anothertag".into())
     custom_el,
 ]
 ```
-An example is provided as part of the [window_events](https://github.com/seed-rs/seed/tree/master/examples/todomvc)
+An example is provided as part of the [window_events](https://github.com/seed-rs/seed/tree/master/examples/window_events)
 example.
 
 ## Local storage
@@ -51,7 +51,7 @@ let data = serde_json::from_str(&loaded_serialized).unwrap();
 
 ## Display markdown and raw HTML
 Seed supports creating elements from markdown text, using [pulldown-cmark](https://github.com/raphlinus/pulldown-cmark)
-internally. Use the [Node::from_markdown()](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Node.html#method.from_markdown)
+internally. Use the [El::from_markdown()](https://docs.rs/seed/latest/seed/virtual_dom/node/el/struct.El.html#method.from_markdown)
 method to create an element that accepts a markdown &str as its only parameter, and displays
 it normally as html. Note that it does not support syntax highlighting. You can render raw HTML with `El::from_html(html)`, where `html` is a 
 &str of HTML. You can also use the `raw!` and `md!` macros for `from_html` and 

--- a/crate/guides/routing.md
+++ b/crate/guides/routing.md
@@ -1,12 +1,12 @@
 # Routing
 Seed includes flexible routing, inspired by 
-[React-Reason](https://github.com/reasonml/reason-react/blob/master/docs/router.md): 
+[Reason-React](https://github.com/reasonml/reason-react/blob/master/docs/router.md): 
 You can trigger state changes that update the address bar,
  and can be nagivated to/from using forward and back buttons. This works for landing-page
 routing as well, provided your server is configured to support. See the
-[todomvc](https://github.com/seed-rs/seed/tree/master/examples/todomvc) example, and 
-the [seed-rs.org](https://github.com/seed-rs/seed-rs.org) repo.
-  
+ seed-rs.org [source](https://github.com/seed-rs/seed-rs.org/tree/master/crate/src) and
+[todomvc](https://github.com/seed-rs/seed/tree/master/examples/todomvc) example.
+
 Let's say our site the following pages:
 a guide, which can have subpages, and a changelog, accessible by `http://seed-rs.org/changelog`,
 `http://seed-rs.org/guide`, and `http://seed-rs.org/guide/3` (where 3 is the page we want) respectively. 
@@ -17,7 +17,7 @@ number for the guide page. An enum would be cleaner, but we don't wish to compli
 ## The basics
 
 To set up the initial routing, pass a `routes` function describing how to handle
-routing, to [App::build](https://docs.rs/seed/0.5.1/seed/struct.App.html#method.build)'s 
+routing, to [App::build](https://docs.rs/seed/latest/seed/app/struct.App.html#method.build)'s 
 `routes` method.
 ```rust
 fn routes(url: Url) -> Option<Msg> {
@@ -65,7 +65,7 @@ button!["Changelog", attrs!{At::Href => "/changelog"} ]
 ## More detail, and routing using events
 
 Your `routes` function outputs the message that handles the routing as an `Option`, and accepts a 
-[Url struct](https://docs.rs/seed/0.5.1/seed/browser/url/struct.Url.html)
+[Url struct](https://docs.rs/seed/latest/seed/browser/url/struct.Url.html)
 describing the route, which routes has the following fields:
 ```rust
 pub struct Url {
@@ -118,11 +118,11 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 }
 ```
 
-Notice how the `Route` messages above call [seed::push_route](https://docs.rs/seed/0.5.1/seed/routing/fn.push_route.html), 
+Notice how the `Route` messages above call [seed::push_route](https://docs.rs/seed/latest/seed/browser/service/routing/fn.push_route.html), 
 and the `Change` messages are called in the `routes` function, and are recursively called in the
 update function. `push_route` accepts a single parameter: a `Url` struct, which you can create with a 
 struct literal, or
- [seed::Url::new](https://docs.rs/seed/0.5.1/seed/routing/struct.Url.html#method.new). Alternatively,
+ [seed::Url::new](https://docs.rs/seed/latest/seed/browser/url/struct.Url.html#method.new). Alternatively,
   you can pass a `Vec<String>` / `Vec<&str>`, representing the path.
 
 ```rust

--- a/crate/guides/structure.md
+++ b/crate/guides/structure.md
@@ -119,9 +119,9 @@ fn update(msg: Msg, model: &mut Model, _orders: &mut impl Orders<Msg>) {
 
 [TODO]: # (This section below is unclear, please improve me)
 
-The third parameter of the update function is an 
-[Orders](https://docs.rs/seed/0.5.1/seed/prelude/struct.Orders.html)
- struct, imported in the prelude.
+The third parameter of the update function implements the  
+[Orders](https://docs.rs/seed/latest/seed/app/orders/trait.Orders.html)
+ trait, imported in the prelude.
 It has four methods, each defining an update behavior:
 
 - `render`: Rerender the DOM, based on the new model. If `orders` is not used for a branch, it
@@ -156,7 +156,6 @@ select the HTML element where the app will be mounted and how it'll be mounted.
 
 And the following mandatory one:
 - `build_and_start` - run at the end, to initialize the app.
-
 
 You can can chain the following optional methods:
 
@@ -205,7 +204,7 @@ pub fn render() {
 
 `AfterMount` has the following fields:
     - `model`: The initial model
-    - `url_handling`: A [Urlhandling](https://docs.rs/seed/0.5.1/seed/enum.UrlHandling.html)  enum, which has 
+    - `url_handling`: A [Urlhandling](https://docs.rs/seed/latest/seed/app/builder/after_mount/enum.UrlHandling.html)  enum, which has 
     variants `PassToRoutes`: default with `Init::new()`),
     and `None`
 

--- a/crate/guides/view.md
+++ b/crate/guides/view.md
@@ -1,15 +1,15 @@
 # View
 
- Visual layout (ie HTML/DOM elements) is described declaratively with [macros]( https://doc.rust-lang.org/book/appendix-04-macros.html) to simplify syntax. Each element
+ Visual layout (ie HTML/DOM elements) is described declaratively with [macros]( https://doc.rust-lang.org/book/ch19-06-macros.html) to simplify syntax. Each element
 is represented by a macro, eg `div![]`. These act as functions that accept an arbitrary
 number of parameters in any order. They handle parameters based exclusively on type.
 
 The view is defined by a function passed to 
-[App::build()](https://docs.rs/seed/0.5.1/seed/struct.App.html#method.build). It takes a `&Model`
+[App::build()](https://docs.rs/seed/latest/seed/app/struct.App.html#method.build). It takes a `&Model`
 as a parameter and outputs something that implements the ` View` trait, which is imported in the prelude.
 Usually, this is a `Node`, or `Vec<Node>`, representing all nodes that will be inserted as children
 on the top-level one. The top-level `Node` exists in the DOM as specified by
-[AppBuilder::mount()](https://docs.rs/seed/0.5.1/seed/struct.AppBuilder.html#method.mount) and defaults to an element with id `app`.
+[AppBuilder::mount()](https://docs.rs/seed/latest/seed/app/builder/struct.Builder.html#method.mount) and defaults to an element with id `app`.
  It may composed into sub-functions, which can be thought of like components in other frameworks. 
 
 Examples:
@@ -33,12 +33,12 @@ This allows you to change between them without changing the function signature.
 [TODO]: # (Explain what `Msg` type parameter means and how it's connected to `update` function)
 
 ## The Node Enum
-The Virtual DOM is represnted by nested [Nodes](https://docs.rs/seed/0.5.1/seed/dom_types/enum.Node.html).
+The Virtual DOM is represnted by nested [Nodes](https://docs.rs/seed/latest/seed/virtual_dom/node/enum.Node.html).
 `Node` has 3 variants: 
 
-- `Text` holds a [Text](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Text.html)
+- `Text` holds a [Text](https://docs.rs/seed/latest/seed/virtual_dom/node/text/struct.Text.html)
 struct. Mostly for internal use, but can be created with `Node::new_text()`.
-- `Element` wraps an [El](https://docs.rs/seed/0.5.1/seed/dom_types/struct.El.html), which is
+- `Element` wraps an [El](https://docs.rs/seed/latest/seed/virtual_dom/node/el/struct.El.html), which is
 the main component of our VDOM. Created using macros, described below.
 - `Empty` is a placeholder that doens't render anything; useful in conditional/ternary logic.
 Created using the `empty![]` macro, or `seed::empty()`.
@@ -53,11 +53,11 @@ use seed::{*, prelude::*};
 
 These macros accept any combination of the following parameters. Each can be ommitted, included once,
 or included multiple times.
-- [Attrs](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Attrs.html) structs
-- [Style](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Style.html) structs
-- [Listener](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Listener.html) structs, which handle events
+- [Attrs](https://docs.rs/seed/latest/seed/virtual_dom/attrs/struct.Attrs.html) structs
+- [Style](https://docs.rs/seed/latest/seed/virtual_dom/style/struct.Style.html) structs
+- [Listener](https://docs.rs/seed/latest/seed/virtual_dom/event_handler_manager/listener/struct.Listener.html) structs, which handle events
 - `String`s or `&str`s representing a node text
-- [Node](https://docs.rs/seed/0.5.1/seed/dom_types/enum.Node.html) structs, representing a child
+- [Node](https://docs.rs/seed/latest/seed/virtual_dom/node/enum.Node.html) structs, representing a child
 - `Vec`s of `Attrs`, `Style`, `Listener`, or `Node`
 - `Map`s of `Attrs`, `Style`, `Listener`, or `Node`, ie the result of `map()`,
  without having to explicitly `collect`
@@ -65,8 +65,7 @@ or included multiple times.
 The parameters can be passed in any order; the compiler knows how to handle them
 based on their types. Children are rendered in the order passed.
 
-Views are described using [El](https://docs.rs/seed/0.5.1/seed/dom_types/struct.El.html) structs, 
-defined in the [seed::dom_types](https://docs.rs/seed/0.5.1/seed/dom_types/index.html) module.
+Views are described using [El](https://docs.rs/seed/latest/seed/virtual_dom/node/el/struct.El.html) structs.
 
 `Attrs` and `Style` are thinly-wrapped hashmaps created with their own macros: `attrs!{}` and `style!{}`
 respectively.
@@ -117,7 +116,7 @@ let style = style![
 ```
 
 We can set multiple values for an attribute using 
-[Attribute.add_multiple](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Attrs.html#method.add_multiple).
+[Attribute.add_multiple](https://docs.rs/seed/latest/seed/virtual_dom/attrs/struct.Attrs.html#method.add_multiple).
  This is useful for setting multiple classes. Note that we must set this up outside of
 the view macro, since it involves modifying a variable:
 ```rust
@@ -130,17 +129,17 @@ fn a_component() -> Node<Msg> {
 ```
 
 Seed validates attributes [against this list](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes);
-The [At](https://docs.rs/seed/0.5.1/seed/dom_types/enum.At.html) 
+The [At](https://docs.rs/seed/latest/seed/dom_entity_names/enum.At.html) 
 enum includes only these values, and `&strs` passed are converted into `At`s. If you
 wish to use a custom attribute, use 
-[At::Custom](https://docs.rs/seed/0.5.1/seed/dom_types/enum.At.html#variant.Custom)
+[At::Custom](https://docs.rs/seed/latest/seed/dom_entity_names/enum.At.html#variant.Custom)
 , eg `At::Custom(name)`, where `name` is a `String` of your
 attribute's name. In `attrs!` when using `&str`s, inserting an unrecognized attribute
 will do the same. Similar `Custom` methods exist for 
-[Style](https://docs.rs/seed/0.5.1/seed/dom_entity_names/styles/enum.St.html#variant.Custom),
-[Namespace](https://docs.rs/seed/0.5.1/seed/dom_types/enum.Namespace.html#variant.Custom),
-[Tag](https://docs.rs/seed/0.5.1/seed/dom_types/enum.Tag.html#variant.Custom), and
-[Category](https://docs.rs/seed/0.5.1/seed/events/enum.Category.html#variant.Custom).
+[Style](https://docs.rs/seed/latest/seed/dom_entity_names/enum.St.html#variant.Custom),
+[Namespace](https://docs.rs/seed/latest/seed/browser/dom/namespace/enum.Namespace.html#variant.Custom),
+[Tag](https://docs.rs/seed/latest/seed/dom_entity_names/enum.Tag.html#variant.Custom), and
+[Event](https://docs.rs/seed/latest/seed/dom_entity_names/enum.Ev.html#variant.Custom).
 
 The `class!` and `id!` convenience macros allow settings
 attributes as a list of classes, or a single id, if no other attributes are required.
@@ -187,7 +186,7 @@ fn a_component() -> Node<Msg> {
 
 For boolean attributes that are handled by presense or absense, like `disabled`, `checked`,
 `autofocus` etc, use 
-[.as_at_value](https://docs.rs/seed/0.5.1/seed/dom_types/values/trait.AsAtValue.html#tymethod.as_at_value):
+[.as_at_value](https://docs.rs/seed/latest/seed/virtual_dom/values/trait.AsAtValue.html#tymethod.as_at_value):
  `input![ attrs!{At::Disabled => false.as_at_value() ]`:
 
 ```rust
@@ -233,7 +232,7 @@ fn view(model: &Model) -> impl View<Msg> {
 ```
 
 We can combine Attrs and `Style` instances using their 
-[merge](https://docs.rs/seed/0.5.1/seed/dom_types/struct.Attrs.html#method.merge)
+[merge](https://docs.rs/seed/latest/seed/virtual_dom/attrs/struct.Attrs.html#method.merge)
  methods, which take
 an `&Attrs` and `&Style` respectively. This can be used to compose styles from reusable parts. 
 Example:
@@ -318,7 +317,7 @@ svg![
 ]
 ```
 
-The same exmaple using [from_html](https://docs.rs/seed/0.5.1/seed/dom_types/enum.Node.html#method.from_html):
+The same exmaple using [from_html](https://docs.rs/seed/latest/seed/virtual_dom/node/el/struct.El.html#method.from_html):
 ```rust
 Node::from_html(
 r#"
@@ -373,7 +372,7 @@ pub fn render() {
 
 ##  Components
 The analog of components in frameworks like React are normal Rust functions that that return
-[Node](https://docs.rs/seed/0.5.1/seed/dom_types/enum.Node.html) s.
+[Nodes](https://docs.rs/seed/latest/seed/virtual_dom/node/enum.Node.html).
 These functions take parameters that are not treated in a way equivalent
 to attributes on native DOM elements; they just provide a way to 
 organize your code. In practice, they're used in a way similar to components in React.
@@ -446,7 +445,7 @@ fn items() -> Node<Msg> {
 ## Dummy elements
 When performing ternary operations inside an element macro, all
 branches must return an `Node` (Or `Vec` of `Node`s) to satisfy Rust's type system. Seed provides the
-[empty](https://docs.rs/seed/0.5.1/seed/fn.empty.html) function, which creates a `Node` that will not be 
+[empty](https://docs.rs/seed/latest/seed/fn.empty.html) function, which creates a `Node` that will not be 
 rendered, and its `empty![]` macro alias, which is more concise and consistent:
 ```rust
 div![


### PR DESCRIPTION
This PR fixes all the broken links in the docs on the website. This PR does not attempt to change any language unless where the link was pointing to no longer exists. This means that some of the content in support.md#initialization is outdated, some of the content in view.md is outdated, and possibly other content too.

fixes: #17 
