### PR TITLE
Update time_tracker_file_structure.md

### DIFF
--- a/crate/guides/0.8.0/time_tracker_file_structure.md
+++ b/crate/guides/0.8.0/time_tracker_file_structure.md
@@ -692,6 +692,7 @@ pub enum Msg {
     ConfirmPasswordChanged(String),
 
     Save,
+    DeleteAccount
 }
 
 pub fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {


### PR DESCRIPTION
Added `DeleteAccount` to the `Msg` in `settings.rs`, corrects a compiler error that happens when you copy the code directly from the page and attempt to run it.