### PR TITLE
Correct grammar in the first half of the App 1 Tutorial

### DIFF
--- a/crate/guides/0.8.0/app_1_counter.md
+++ b/crate/guides/0.8.0/app_1_counter.md
@@ -4,9 +4,9 @@
 
 [Live Demo](https://seed-app-counter.netlify.app/) |  [Repository](https://github.com/MartinKavik/seed-app-counter) |  [Playground](https://ide.play-seed.dev/?github=MartinKavik/seed-app-counter)
 
-Counter example is the default example in the [basic quickstart](https://github.com/seed-rs/seed-quickstart) so you don't have to modify code at all.
+The counter example is the default example in the [basic quickstart](https://github.com/seed-rs/seed-quickstart), so you don't have to modify code in this tutorial at all.
 
-The entire code (`/src/lib.rs` content) without comments and extra items to satisfy linters:
+Below is the entire code (`/src/lib.rs` content) without comments and extra items to satisfy linters:
 
 ```rust
 use seed::{prelude::*, *};
@@ -41,4 +41,4 @@ pub fn start() {
 }
 ```
 
-You'll learn about individual parts (`Model`, `update`, etc.) in the next chapters. If you want to zoom out a bit before we'll jump into the rabbit hole, I recommend to read something about [The Elm Architecture (TEA)](https://guide.elm-lang.org/architecture/).
+You'll learn about individual parts (`Model`, `update`, etc.) in the next chapters. If you want to zoom out a bit before we jump into the rabbit hole, I recommend to read something about [The Elm Architecture (TEA)](https://guide.elm-lang.org/architecture/).

--- a/crate/guides/0.8.0/init.md
+++ b/crate/guides/0.8.0/init.md
@@ -7,7 +7,7 @@ Counter example part:
 //     Init
 // ------ ------
 
-// `init` describes what should happen when your app started.
+// `init` describes what should happen when your app starts
 fn init(_: Url, _: &mut impl Orders<Msg>) -> Model {
     Model::default()
 }
@@ -44,14 +44,16 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
 
 - The main purpose of this function is to create a `Model` instance.
 
-- `init` function is called only once, when your app started.
+- The `init` function is only called when your app starts.
 
-In the Counter example, `init` parameters don't have names (there is only `_` as a placeholder) . It signals to readers, the compiler and linters that we don't use those parameters in the function body. (_Note:_ We can also add only prefix `_` before the names (`_url` and `_orders`) instead, but it's relatively easy to overlook `_` and Clippy can be sad about that because it doesn't ignore prefixed names (unlike the compiler - it ignores them).)
+In the Counter example, `init` parameters don't have names, instead using `_` as a placeholder. This lets readers, linters, and the compiler know that we don't use those parameters in the function body. 
+
+_Note:_ We can also prefix `_` before variable names (e.g. `_url` and `_orders`), but it's relatively easy to overlook `_`. Clippy also complains about that because it doesn't ignore prefixed names, unlike the compiler.
 
 ## Parameter `url: Url`
 
-It's very common that some fields in your `Model` depend on the current Url.
-You'll often write the code similar to:
+It's very common for some fields in your `Model` depend on the current URL.
+You'll often write the similar to the example below:
 ```rust
 fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
     ...
@@ -60,13 +62,13 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
         page: Page::init(url),
         ...
 ```
-That's why we decided to add parameter `url` - for your comfort (aka _developer experience_) - you don't have to go through the documentation every time you need to get `Url` and introduce side-effects or slow JS calls into your code-base by trying to get it directly from the browser.
+That's why we decided to add the `url` parameter - for your comfort (aka _developer experience_). You don't have to go through the documentation every time you need to get `Url` and introduce side effects or slow JS calls into your codebase by trying to get it directly from the browser.
 
 ## Parameter `orders: &mut impl Orders<Msg>`
 
-It's the way how you are "giving orders" to Seed. Do you want to send an HTTP request? Do you want to subscribe to Url changes? Do you want to do something after 5 seconds? Well, use `orders`.
+Think of this parameter as "giving orders" to Seed. Do you want to send an HTTP request? Do you want to subscribe to URL changes? Do you want to do something after 5 seconds? Well, use `orders`.
 
-`orders` has many useful methods, we will discuss them in other chapters. Example usage:
+`orders` has many useful methods, and we will discuss them in later chapters. Here's a usage example:
 
 ```rust
 fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
@@ -81,33 +83,33 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
 <details>
 <summary>Why does <code>orders</code> have such a weird type??</summary>
 
-Well, let me explain why it hasn't got a simpler type instead. There are possible options: 
+Well, let me explain why it doesn't have a simpler type. There are possible options: 
 
 1. Without `&mut`
    - `fn init(_: Url, orders: impl Orders<Msg>) -> Model`
    
-   - `orders` contains data like a side-effect queue. So when you call e.g. `orders.perform_cmd(.. fetch ..)` you basically modifies the queue. We can move the queue into a wrapper with [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html#interior-mutability-a-mutable-borrow-to-an-immutable-value), but it isn't idiomatic or explicit enough and it would be slower and more error-prone.
+   - `orders` contains data like a queue, and calling something like `orders.perform_cmd(.. fetch ..)` modifies the queue. We can move the queue into a wrapper with [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html#interior-mutability-a-mutable-borrow-to-an-immutable-value), but that isn't idiomatic or explicit enough, would be slower, and is more error-prone.
 
 
 1. Without `<Msg>`
    - `fn init(_: Url, orders: &mut impl Orders) -> Model`
    
-   - The compiler and IDEs need help - without it they don't know if our HTTP response handlers return the expected `Msg` type or they can't show you possible options in autocomplete lists.
+   - The compiler and IDEs need help - they can't infer that our HTTP response handlers return the expected `Msg` type, and they can't show you possible options in autocomplete lists without it.
    
-   - We can hide `<Msg>` by some magic provided by [Any](https://doc.rust-lang.org/std/any/), but you are basically trying to remove static types from Rust.. it's not idiomatic of course and very error-prone.
+   - We can hide `<Msg>` through some magic provided by the [any](https://doc.rust-lang.org/std/any/) module in the standard library, but doing that would be like trying to remove static types from Rust. It's not idiomatic of course and very error-prone.
 
 1. Without `impl`
    - `fn init(_: Url, orders: &mut Orders<Msg>) -> Model`
 
-   - `orders` contains a reference to `App` instance - it's required by some `orders` methods and there are some cases when it's useful for users, too. However struct `App` requires multiple type parameters. And we don't want to "leak" them into `orders` - it would look like `orders: &mut Orders<Msg, Model, Vec<Node<Msg>>>`. So `Orders` isn't a specific type but a [trait](https://doc.rust-lang.org/book/ch10-02-traits.html#traits-defining-shared-behavior). And those extra `App` types are hidden in `Orders`'s [associated types](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types) with [impl](https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters) help. (_Note:_ We can't hide also type parameter for `Msg` because it would cause cumbersome "type acrobatics" in your components.)
+   - `orders` contains a reference to the `App` instance - it's required by some `orders` methods and there are some cases where it's useful for users, too. The `App` struct, however, requires multiple type parameters, and we don't want to "leak" them into `orders` - doing this would look something like `orders: &mut Orders<Msg, Model, Vec<Node<Msg>>>`. As a result, `Orders` isn't a specific type but a [trait](https://doc.rust-lang.org/book/ch10-02-traits.html#traits-defining-shared-behavior), and those extra `App` types are hidden in `Orders`'s [associated types](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types) with [impl](https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters) help. (_Note:_ We also can't hide type parameter for `Msg` because it would cause cumbersome "type acrobatics" in your components.)
 
 </details>
 
-## How to write a good `init`
+## How to write a good `init` function
 
-- `init` should be short and simple - the main goal is to just create a new `Model` instance. Also it blocks the app - try to invoke time-consuming operations in other functions (especially in `update` function; you'll learn about `update` in next chapters) when the app is rendered and the user is happy that he sees at least some content.
+- Your `init` function should be short and simple - the main goal is to just create a new `Model` instance. Furthermore, it blocks the app - try to invoke time-consuming operations in other functions (especially in `update` function; you'll learn about `update` in next chapters) when the app is rendered and the user is happy that he sees at least some content.
 
-- When you need to write some helpers, respect the rule *"children below the parent"* - write helpers below the `init` function. And once you find out you are using some helpers also in `update` function, move them below the `update`.
+- When you need to write some helpers, respect the *"children below the parent"* rule - write helpers below the `init` function, and you are using some helpers in the `update` function, move them below it.
 
 ---
 

--- a/crate/guides/0.8.0/model.md
+++ b/crate/guides/0.8.0/model.md
@@ -37,21 +37,21 @@ pub struct Model {
 
 - In our case, it's a struct with a single [i32](https://doc.rust-lang.org/book/ch03-02-data-types.html#integer-types) field because we only need to track one value - the number of clicks.
 
-- It can be almost anything - [type alias](https://doc.rust-lang.org/book/ch19-04-advanced-types.html?highlight=alias#creating-type-synonyms-with-type-aliases), [enum](https://doc.rust-lang.org/book/ch06-00-enums.html), etc. However, most `Model`s are [structs](https://doc.rust-lang.org/book/ch05-00-structs.html) in real-world apps. And `Model` has to be `static` (it basically means that you can't save the most [references](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#references-and-borrowing) into it).
+- It can be almost anything -  a [type alias](https://doc.rust-lang.org/book/ch19-04-advanced-types.html?highlight=alias#creating-type-synonyms-with-type-aliases), [enum](https://doc.rust-lang.org/book/ch06-00-enums.html), etc. Most `Model`s, however, are [structs](https://doc.rust-lang.org/book/ch05-00-structs.html) in real-world apps, and your `Model` has to be `static` (you can't save most [references](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#references-and-borrowing) in it).
 
 ## How to write a good `Model`
 
-- It should be as simple as possible. If there is a way how to derive data from the current `Model` instead of extending it (i.e. adding more fields), you should derive it, even at the cost of small reduction in performance.
+- It should be as simple as possible. If there is a way to derive data from the current `Model` instead of extending it (i.e. adding more fields), you should derive it, even at the cost of a small reduction in performance.
 
-- Try to save only data into your `Model` - i.e. add field `students: Vec<Student>` instead of `manager: SchoolManager`, where `manager` contains `Vec<Student>` and a thousand other things. Exceptions are Seed-related items like handles and DOM elements (we will discuss them in other chapters).
+- Try to only save data in your `Model` - i.e. add field `students: Vec<Student>` instead of `manager: SchoolManager`, where `manager` contains `Vec<Student>` and a thousand other things. Exceptions include Seed-related items like handles and DOM elements, which will be discussed in later chapters. 
 
-- Don't make your life unnecessary hard.
+- Don't make your life unnecessarily hard.
   - Don't make your `Model` [generic](https://doc.rust-lang.org/book/ch10-00-generics.html).
-  - Don't implement any `Model` methods (not even [default](https://doc.rust-lang.org/std/default/trait.Default.html) - see detailed explanation at the end of the section).
+  - Don't implement any `Model` methods (not even [default](https://doc.rust-lang.org/std/default/trait.Default.html) - see the detailed explanation at the end of the section).
 
 - Your `Model` should be [the single source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth) - i.e. add one field `selected_menu_item: MenuItemId` into your main `Model` instead of creating many instances of the component `MenuItem`, where each instance has own `Model` with field `selected: bool`.
 
-- Try to be as expressive as possible and make impossible business rules unrepresentable in code by encoding them with Rust type system.
+- Try to be as expressive as possible and make impossible business rules unrepresentable in code by encoding them with the Rust type system.
 
    - Try to reduce the number of `bool`s and `Option`s to a minimum.
 
@@ -59,7 +59,7 @@ pub struct Model {
 
    - I recommend reading the book [Domain Modeling Made Functional](https://fsharpforfunandprofit.com/books/) or at least [The "Designing with types" series](https://fsharpforfunandprofit.com/series/designing-with-types.html).
 
-- When you need to create custom types that are used in the `Model`, write them below the `Model`. (The rule *"children below the parent"* is valid for all nested structures.) Example:
+- When you need to create custom types that are used in the `Model`, write them below the `Model`. The *"children below the parent"* rule is valid for all nested structures. Example:
 ```rust
 // ------ ------
 //     Model
@@ -79,7 +79,7 @@ enum AType {
 <details>
 <summary>Why children below the parent?</summary>
 
-Imagine the code with this pattern:
+Imagine some code with this pattern:
 ```
 ChildA
 impls for ChildA
@@ -88,13 +88,13 @@ ChildC
 ..
 Parent
 ```
-You don't know what children are interesting for you because you don't know how and where they are used until you see also the parent.
+In this pattern, you don't know which children are interesting for you because you don't know how and where they are used until you see also the parent.
 
 Human short-term memory can hold only cca 7 items - that means it's very easily overloaded by reading child definitions and as a result the reader will start to jump between children and the parent to empty space and decrease cognitive load.
 
 You can improve DX by moving children below the parent to allow readers to filter interesting children.
 
-Another reason is scanning - readers (especially advanced developers) scan the code and try to recognize familiar patterns or basic building blocks - then blocks like
+Another reason is scanning - readers (especially advanced developers) scan the code and try to recognize familiar patterns or basic building blocks - blocks like
 ```rust
 // ------ ------
 //     xxxxx
@@ -107,38 +107,38 @@ effectively work as checkpoints for the eyes.
 </details>
 
 <details>
-<summary>Why don't implement <code>Default</code> and other standard traits</summary>
+<summary>Why not to implement <code>Default</code> and other standard traits</summary>
 
-Generally all implementations of standard traits (`From`, `Into`, `Default`, `Display`) are very useful if the item (`struct`, `enum`...) is used in multiple contexts or with multiple other items - then the generalization makes sense because it implies you are writing idiomatic Rust and it plays nicely with other standard traits and other items.  However, when you start to implement standard traits for many items, your code-base is slowly turning into the sea of `.into()`, `::default()`, `.to_string()`, etc.
+All implementations of standard traits (e.g. `From`, `Into`, `Default`, `Display`) are generally very useful only if the item (`struct`, `enum`...) is used in multiple contexts or with multiple other items - the generalization then makes sense because it implies that you are writing idiomatic Rust, and it plays nicely with other standard traits and items.  However, when you start to implement standard traits for many items, your codebase slowly turns into a sea of `.into()`, `::default()`, `.to_string()`, etc.
 
 As the result:
 
-   - You lose expressive domain-specific names so it can be pretty hard to orient in the code.
-   - It bloats the code because standard traits have to cover many cases so they tend to be more complicated.
-   - You need to "bend" some parts of your code so it can be written with those implemented traits - it also makes the code harder to read and probably slower.
+   - You lose expressive domain-specific names, so it can be pretty hard to orient yourself when reading the code.
+   - It bloats the code because standard traits have to cover many cases, so they tend to be more complicated.
+   - You need to "bend" some parts of your code so they can be written with those implemented traits, which also makes the code harder to read and likely slows it down.
 
-**`Default` trait**: We assume `xx::default()` calls are pretty cheap operations (see `Default` for [primitive types](https://doc.rust-lang.org/src/core/default.rs.html#132) or [Vec](https://doc.rust-lang.org/src/alloc/vec.rs.html#2334-2339)) - in the most cases there isn't even memory allocation on the heap and you probably won't find more expensive operations in `Default` implementations for other items. So when you write more sophisticated `Default` code for your item and somebody use this item in a nested structure, he will be very surprised once he writes some benchmarks.
+**`Default` trait**: We assume `xx::default()` calls are pretty cheap operations (see `Default` for [primitive types](https://doc.rust-lang.org/src/core/default.rs.html#132) or [Vec](https://doc.rust-lang.org/src/alloc/vec.rs.html#2334-2339)) - in most cases there isn't even memory allocation on the heap, and you probably won't find more expensive operations in `Default` implementations for other items. When you write more sophisticated `Default` code for your item and somebody uses this item in a nested structure, he will be very surprised once he writes some benchmarks.
 
-One Seed user was even able to accidentally write recursive loop of nested complex `Default`s that was causing stack overflow.
+One Seed user was even able to accidentally write a recursive loop of nested complex `Default`s that was causing stack overflows.
 
-In Seed apps, you need to create `Model` only once, so when you implement `Default` for `Model`:
+In Seed apps, you only need to instantiate `Model` once, so when you implement `Default` for `Model`:
   - It only bloats the code.
-  - You'll have tendency to overwrite default values in `init` function because some `Model` parts will depend on `Url` or on other values => worse readability and slower code. (You'll learn about `init` and `Url` in other chapters.)
-  - It sends misleading signal that `Model` is/can be created on multiple places.
+  - You'll have a tendency to overwrite default values in the `init` function because some `Model` parts will depend on `Url` or other values which results in worse readability and slower code. (You'll learn about `init` and `Url` in later chapters.)
+  - It sends the misleading signal that `Model` is/can be created on multiple places.
 
 </details>
 
 
 ## Single source of truth VS Components
 
-A standard Seed app usually contains one app (aka root or main) `Model`, several  page `Model`s and a few component `Model`s. It's often pretty clear where you should save data and it's simple enough to keep the most of your models in your head during development. So there usually aren't problems with data synchronization or introducing unnecessary models (aka local states).
+A standard Seed app usually contains one app (aka root or main) `Model`, several page `Model`s and a few component `Model`s. It's often pretty clear where you should save data, and it's simple enough to keep the most of your models in your head during development. Due to this, there usually aren't problems with data synchronization or introducing unnecessary models (aka local states).
 
-However it's already possible to integrate Javascript [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) (we plan to support also Rust Web Components) and [React-like Hooks](https://reactjs.org/docs/hooks-overview.html#state-hook) - [Seed Hooks](https://seed-style-hooks.netlify.app/hooks_home) - are waiting for integration into Seed. It means it will be pretty easy to create local states (even implicitly when you are using a component library), so there are some tips how to define your `Model`s:
+It's already possible, however, to integrate Javascript [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) (we plan to support Rust Web Components as well) and [React-like Hooks](https://reactjs.org/docs/hooks-overview.html#state-hook) ([Seed Hooks](https://seed-style-hooks.netlify.app/hooks_home)) are waiting to be integrated into Seed. It will become pretty easy to create local states (even implicitly when you are using a component library), so here are some tips how to define your `Model`s:
 
 1. Your business data should be kept in standard Seed `Model`s - ideally in the app model or in page models.
 
-1. Then you should use state hooks for pure GUI data - e.g. a state variable `mouse_over` for `button` component when you want only to switch the button's color on hover.
+1. You should use state hooks for pure GUI data - e.g. a state variable `mouse_over` for a `button` component when you want only to switch the button's color on hover.
 
-1. And you can use Web Components for complex GUI elements or when you often need to interact with JS library / component.
+1. You can use Web Components for complex GUI elements or when you often need to interact with JS library / component.
 
-(Don't worry, you'll learn more about Web Components and pages in other chapters; or look at [custom_elements](https://github.com/seed-rs/seed/tree/d514b2131a9e94f5ffe965f3d0ac74763a11aeb6/examples/custom_elements) and [pages](https://github.com/seed-rs/seed/tree/d514b2131a9e94f5ffe965f3d0ac74763a11aeb6/examples/pages) examples if you are brave enough.)
+(Don't worry, you'll learn more about Web Components and pages in later chapters- take look at [custom_elements](https://github.com/seed-rs/seed/tree/d514b2131a9e94f5ffe965f3d0ac74763a11aeb6/examples/custom_elements) and [pages](https://github.com/seed-rs/seed/tree/d514b2131a9e94f5ffe965f3d0ac74763a11aeb6/examples/pages) examples if you're brave enough.)

--- a/crate/guides/0.8.0/msg.md
+++ b/crate/guides/0.8.0/msg.md
@@ -45,9 +45,9 @@ pub enum Msg {
 - All `Msg` variants should be as simple as possible and hold only data or ideally nothing.
    - Example: `enum Msg { MenuItemClicked(MenuItemId), Save }`
 
-- If you can choose the type for your ids (e.g. `MenuItemId`), pick rather [Uuid](https://docs.rs/uuid/0.8.1/uuid/struct.Uuid.html) than [String](https://doc.rust-lang.org/std/string/struct.String.html) or [u32](https://doc.rust-lang.org/std/primitive.u32.html). `Uuid` implements [Copy](https://doc.rust-lang.org/std/marker/trait.Copy.html) and allows you to create entities in your frontend app before they are sent to your server.
+- If you can choose the type for your ids (e.g. `MenuItemId`), pick [Uuid](https://docs.rs/uuid/0.8.1/uuid/struct.Uuid.html) rather than [String](https://doc.rust-lang.org/std/string/struct.String.html) or [u32](https://doc.rust-lang.org/std/primitive.u32.html). `Uuid` implements [Copy](https://doc.rust-lang.org/std/marker/trait.Copy.html) and allows you to create entities in your frontend app before they are sent to your server.
 
-- Don't make your life unnecessary hard.
+- Don't make your life unnecessarily hard.
    - Don't make your `Msg` [generic](https://doc.rust-lang.org/book/ch10-00-generics.html).
    - Don't implement any `Msg` methods.
 
@@ -61,9 +61,9 @@ pub enum Msg {
 
 > `#[derive(Copy, Clone)]`
 
-We already know attribute `allow` from the previous chapters. 
+We already know about the `allow` attribute from the previous chapters. 
 
-However the most used is probably attribute `derive`. I recommend to read official documentation, especially these parts:
+The most used attribute, however, is likely `derive`. I recommend reading the official documentation, particularly these parts:
 - [Adding Useful Functionality with Derived Traits](https://doc.rust-lang.org/book/ch05-02-example-structs.html#adding-useful-functionality-with-derived-traits)
 - [Appendix C: Derivable Traits](https://doc.rust-lang.org/book/appendix-03-derivable-traits.html#appendix-c-derivable-traits)
 - [Clone and Copy for Duplicating Values](https://doc.rust-lang.org/book/appendix-03-derivable-traits.html#clone-and-copy-for-duplicating-values)
@@ -71,16 +71,16 @@ However the most used is probably attribute `derive`. I recommend to read offici
 
 **Notes from the front line:**
 
-- Derive `Copy, Clone` for all items, where possible. It will make your life easier and your users and Clippy will appreciate it, too.
+- Derive `Copy` and `Clone` for all items, where possible. It will make your life easier, and both Clippy and your users will appreciate it.
   - Some `derive` values are order-sensitive because they are sequentially applied to the code below them. That's why the alphabetical order in `derive(..)` is not important and by convention `Copy` should be always before `Clone` for better code scannability.
 
-- There are edge-cases where you derive `Clone`, compiler is ok with it but you have still problems with calling `my_item.clone()`. In the most cases you can resolve it by implementing `Clone` manually. ([Related Rust issue](https://github.com/rust-lang/rust/issues/26925))
+- There are edge-cases where you derive `Clone` without any compilation issues, but you have still problems with calling `my_item.clone()`. In the most cases, you can resolve this by implementing `Clone` manually. ([Related Rust issue](https://github.com/rust-lang/rust/issues/26925))
 
-- Derive `Debug` at least for public items, if possible. Users will be able to fix the most of bugs in their apps and you'll receive more meaningful bug reports. Seed has macro `log!(item_a, item_b);` that you can use instead of `println!` to log things that implement `Debug` into the browser console log.
+- Derive `Debug` at for all public items, if possible. Users will be able to fix the most of the bugs in their apps, and you'll receive more meaningful bug reports. Seed has a `log!(item_a, item_b);` macro that you can use instead of `println!` to log things that implement `Debug` directly to the browser console.
 
-- Derive `Default` when you are sure it's really useful. If you decide to implement `Default` manually, make it super simple.
+- Only derive `Default` when you are sure it's really useful. If you decide to implement `Default` manually, make it as simple as possible.
 
-- `Eq` and `PartialEq` is often useful for simple enums. It allows you to use `==` as the more readable alternative to [pattern matching](https://doc.rust-lang.org/book/ch06-00-enums.html) and macros like [matches!](https://doc.rust-lang.org/beta/std/macro.matches.html). Example:
+- `Eq` and `PartialEq` are often useful for simple enums. They allow you to use the `==` operator, as opposed to things like [pattern matching](https://doc.rust-lang.org/book/ch06-00-enums.html) and the [matches!](https://doc.rust-lang.org/beta/std/macro.matches.html) macro, which are less readable. Example:
 
 ```rust
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/crate/guides/0.8.0/use.md
+++ b/crate/guides/0.8.0/use.md
@@ -49,25 +49,25 @@ div![
     ev(Ev::Click, |_| Msg::Save)
 ]
 ``` 
-Fortunately, `ev` and `Ev` are "hidden" behind the star (aka glob operator / asterisk wildcard) in `prelude::*`. Module `prelude` is a standard way in Rust world to group the most used items in your library so users can import them all at once.
+Fortunately, `ev` and `Ev` are "hidden" behind the star (aka glob operator / asterisk wildcard) in `prelude::*`. Module `prelude` is a standard way in the Rust world to group the most used items in your library so users can import them all at once.
 
 However [macros](https://doc.rust-lang.org/book/ch19-06-macros.html) live only in the root, so we can't import them through `prelude` - we have to include them from root => 2nd star in `use seed::{prelude::*, *};`. There are many macros in Seed library because all elements are macros - `div!`, `span!`, etc. So it's practical to include them at once, too.
 
-(_Note:_ Don't bother to learn about `ev`, `Ev`, elements and macros now, we will look at them in other chapters.)
+(_Note:_ Don't bother to learn about the `ev`, `Ev`, elements and macros now, we will look at them in later chapters.)
 
-Seed also automatically includes some [traits](https://doc.rust-lang.org/book/ch10-02-traits.html) and macro helpers through those stars - they are needed for user comfort and performance - it would be pain to include them manually.
+Seed also automatically includes some [traits](https://doc.rust-lang.org/book/ch10-02-traits.html) and macro helpers through those stars - they are needed for user comfort and performance - it would be a pain to include them manually.
 
 ## Rust Attributes [[docs]](https://doc.rust-lang.org/reference/attributes.html#attributes)
 
 > `#![allow(clippy::wildcard_imports)]`
 
-[Clippy](https://github.com/rust-lang/rust-clippy) is the official Rust linter. It has many useful rules that help you to write faster and more readable code. However programming is often more art than science so Clippy is sometimes annoying and doesn't let you to write cleaner code that breaks a rule.
+[Clippy](https://github.com/rust-lang/rust-clippy) is the official Rust linter. It has many useful rules that help you to write faster and more readable code. Programming is often more art than science, however, so Clippy is sometimes annoying and doesn't let you to write cleaner code that breaks a rule.
 
-One of these rules is [wildcard_imports](https://rust-lang.github.io/rust-clippy/stable/index.html#wildcard_imports). It's generally a good best practice, but it fights with our `use seed::{prelude::*, *};` - and we have good reasons for these wildcards (as we explained in the previous section). So we have to disable this rule. There are multiple ways but we need only two in practice:
+One of these rules is [wildcard_imports](https://rust-lang.github.io/rust-clippy/stable/index.html#wildcard_imports). It's generally a good best practice, but it fights with our `use seed::{prelude::*, *};` - and we have good reasons for these wildcards (as we explained in the previous section), so we have to disable this rule. There are multiple ways to accomplish this, but we only need two in practice:
 1. `#![allow(clippy::wildcard_imports)]` - with bang (`!`) - disable selected rule(s) for all items in the same scope / module.
 1. `#[allow(clippy::wildcard_imports)]` - without bang - disable selected rule(s) only for the item below.
 
-There are many more Rust Attributes, we will explain other ones when needed.
+There are many more Rust Attributes, and we will explain other ones when needed.
 
 ---
 


### PR DESCRIPTION
Next part coming soon (I plan on correcting all of the guide tutorials for 0.8.0), just figured that the faster these are in the better it is for users.