### PR TITLE
Minor fixes to todomvc guide.

### DIFF
--- a/crate/guides/0.8.0/todomvc_link_building.md
+++ b/crate/guides/0.8.0/todomvc_link_building.md
@@ -87,12 +87,12 @@ fn view_filters(selected_filter: Filter) -> Node<Msg> {
 
 ## 2. Standard link building
 
-The routing code and links are now good enough. 
+The routing code and links are now good enough.
 
 However it's not a standard way how to create links in Seed apps. Once you have a larger app with nested paths and pages, you don't want to know parent path parts - the only interesting ones are path parts related to the particular page.
 
 Example:
-  - Paths: 
+  - Paths:
      - `/admin/statistics/report/daily`
      - `/admin/statistics/report/weekly`
   - Pages: `admin`, `statistics`, `report`
@@ -189,7 +189,7 @@ We've moved field `base_url` at the top because:
    - The value is initiated by using `url`, so it has to be placed above `filter: Filter::from(url)` because `Filter::from` consumes `url` (i.e. takes ownership).
    - It's a common part of Seed apps - it allows a bit faster code scanning for experienced Seed users.
 
-`Url` method `to_hash_base_url()` deletes all path parts with index >= `next_hash_path_part_index` in the cloned url. In our case it removes all path parts because `next_hash_path_part_index` is always set to 0 in `url` in `init`. 
+`Url` method `to_hash_base_url()` deletes all path parts with index >= `next_hash_path_part_index` in the cloned url. In our case it removes all path parts because `next_hash_path_part_index` is always set to 0 in `url` in `init`.
 
 `to_hash_base_url()` returns the cloned url that will be used as a base url for our links as you'll see later.
 
@@ -252,7 +252,7 @@ impl<'a> Urls<'a> {
             base_url: base_url.into(),
         }
     }
-    pub fn base_url(self) ->Url {
+    pub fn base_url(self) -> Url {
         self.base_url.into_owned()
     }
 }

--- a/crate/guides/0.8.0/todomvc_refactor.md
+++ b/crate/guides/0.8.0/todomvc_refactor.md
@@ -297,11 +297,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         }
         Msg::ClearCompleted => {
-            // TODO: Refactor with `BTreeMap::drain_filter` once stable.
-            model.todos = mem::take(&mut model.todos)
-                .into_iter()
-                .filter(|(_, todo)| not(todo.completed))
-                .collect();
+            model.todos.retain(|(_, todo)| not(todo.completed));
         }
 
         // ------ Selection ------

--- a/crate/guides/0.8.0/todomvc_routing.md
+++ b/crate/guides/0.8.0/todomvc_routing.md
@@ -439,11 +439,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         }
         Msg::ClearCompleted => {
-            // TODO: Refactor with `BTreeMap::drain_filter` once stable.
-            model.todos = mem::take(&mut model.todos)
-                .into_iter()
-                .filter(|(_, todo)| not(todo.completed))
-                .collect();
+            model.todos.retain(|(_, todo)| not(todo.completed));
         }
         
         // ------ Selection ------

--- a/crate/guides/0.8.0/todomvc_update.md
+++ b/crate/guides/0.8.0/todomvc_update.md
@@ -158,8 +158,6 @@ And don't forget to check that everything works after each step as usual.
     ...
     ```
 
-    _Note:_ We could make the filter pipeline nicer with the help of [apply](https://crates.io/crates/apply) or a custom BTreeMap-[extending trait](http://xion.io/post/code/rust-extension-traits.html), but let's wait for [BTreeMap::drain_filter](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.drain_filter) stabilization.
-
 1. `Msg::CheckOrUncheckAll`
 
     ```rust

--- a/crate/guides/0.8.0/todomvc_update.md
+++ b/crate/guides/0.8.0/todomvc_update.md
@@ -145,11 +145,7 @@ And don't forget to check that everything works after each step as usual.
         match msg {
             ...
             Msg::ClearCompleted => {
-                // TODO: Refactor with `BTreeMap::drain_filter` once stable.
-                model.todos = mem::take(&mut model.todos)
-                    .into_iter()
-                    .filter(|(_, todo)| not(todo.completed))
-                    .collect();
+                model.todos.retain(|(_, todo)| not(todo.completed));
             }
     ...
 

--- a/crate/guides/0.8.0/todomvc_view.md
+++ b/crate/guides/0.8.0/todomvc_view.md
@@ -646,8 +646,8 @@ Let's integrate it into our app!
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Template • TodoMVC</title>
-        <link rel="stylesheet" href="css/base.css">
-        <link rel="stylesheet" href="css/index.css">
+        <link data-trunk rel="css" href="css/base.css">
+        <link data-trunk rel="css" href="css/index.css">
     </head>
 
     <body>
@@ -681,7 +681,7 @@ Let's integrate it into our app!
     #[wasm_bindgen(start)]
     pub fn start() {
         console_error_panic_hook::set_once();
-        
+
         let root_element = document()
             .get_elements_by_class_name("todoapp")
             .item(0)


### PR DESCRIPTION
### Here is a couple of issues I encountered while working through the todomvc example:

- Linking css files with trunk

    While I was working through the example I could not get the css files to load with the regular html links using
    `trunk serve`.
    It would instead serve the `index.html` for whatever url I fetched from it.

    When checking the trunk docs they only talk about including stylesheets with their specific `data-trunk` links so that's what I tried and that's the way it worked for me.

- Use of a workaround while waiting for `drain_filter` to stabilize when `retain` is available

- I also found some whitespace errors and thought I'd fix them while in the files.

Thanks for your time!