### PR TITLE
Fixes to todomvc_view.md

### DIFF
--- a/crate/guides/0.8.0/todomvc_view.md
+++ b/crate/guides/0.8.0/todomvc_view.md
@@ -646,8 +646,8 @@ Let's integrate it into our app!
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Template • TodoMVC</title>
-        <link data-trunk rel="css" href="css/base.css">
-        <link data-trunk rel="css" href="css/index.css">
+        <link data-trunk rel="stylesheet" href="css/base.css">
+        <link data-trunk rel="stylesheet" href="css/index.css">
     </head>
 
     <body>
@@ -747,7 +747,6 @@ Let's integrate it into our app!
         <!-- Hidden if no completed items are left ↓ -->
         <button class="clear-completed">Clear completed</button>
     </footer>
-    </section>
     ```
     </details>
 


### PR DESCRIPTION
Fixing two [invalid](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) `rel` attribute values and removing a rogue `</section>` tag.